### PR TITLE
Handle file extension issue with mac

### DIFF
--- a/app/models/audio_file.rb
+++ b/app/models/audio_file.rb
@@ -4,6 +4,6 @@ class AudioFile < ApplicationRecord
   has_one_attached :attached_file
 
   def url
-    calculate_url(attached_file)
+    "#{calculate_url(attached_file)}.#{attached_file.filename.extension}"
   end
 end

--- a/app/models/audio_file.rb
+++ b/app/models/audio_file.rb
@@ -4,6 +4,6 @@ class AudioFile < ApplicationRecord
   has_one_attached :attached_file
 
   def url
-    "#{calculate_url(attached_file)}.#{attached_file.filename.extension}"
+    calculate_url(attached_file)
   end
 end

--- a/app/models/concerns/file_storage.rb
+++ b/app/models/concerns/file_storage.rb
@@ -9,7 +9,12 @@ module FileStorage
   end
 
   def file_storage_host_url(storage_obj)
-    "#{ENV.fetch('FILE_STORAGE_HOST')}/#{storage_obj.key}"
+    [
+      ENV.fetch('FILE_STORAGE_HOST', nil),
+      storage_obj.key,
+      'blob',
+      "#{storage_obj.filename.base}.#{storage_obj.filename.extension}",
+    ].join('/')
   end
 
 end


### PR DESCRIPTION
Some background on this code:

Mac's don't like it when a file has no extension. ActiveStorage stores its identifiers as blob hashes.

With this PR, the generated URL contains the hash,and  ends with the original file name and extension. The browser hits CloudFront, and Lambda@Edge (external coupling) truncates the URL to just have the blob at the end.

This should work better: https://github.com/rails/rails/pull/34477